### PR TITLE
add reward_range property

### DIFF
--- a/spriteworld/gym_wrapper.py
+++ b/spriteworld/gym_wrapper.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 from dm_env import specs
 from gym import spaces
+from gym.core import Env as gym_env
 import numpy as np
 
 
@@ -53,6 +54,7 @@ class GymWrapper(object):
     self._last_render = None
     self._action_space = None
     self._observation_space = None
+    self._reward_range = None
 
     # Reset Spriteworld to setup the observation_specs correctly
     self._env.reset()
@@ -75,6 +77,15 @@ class GymWrapper(object):
     if self._action_space is None:
       self._action_space = _spec_to_space(self._env.action_spec())
     return self._action_space
+
+  @property
+  def reward_range(self):
+    if self._reward_range is None:
+      if hasattr(self, '_task') and hasattr(self._task, '_reward_range'):
+        self._reward_range = (-self._task._reward_range, 0)
+      else:
+        self._reward_range = gym_env.reward_range  # (-float('inf'), float('inf'))
+    return self._reward_range
 
   def _process_obs(self, obs):
     """Convert and processes observations."""

--- a/spriteworld/gym_wrapper.py
+++ b/spriteworld/gym_wrapper.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 from dm_env import specs
 from gym import spaces
-from gym.core import Env as gym_env
+from gym.core import Env as gym_default_env
 import numpy as np
 
 
@@ -54,7 +54,6 @@ class GymWrapper(object):
     self._last_render = None
     self._action_space = None
     self._observation_space = None
-    self._reward_range = None
 
     # Reset Spriteworld to setup the observation_specs correctly
     self._env.reset()
@@ -80,12 +79,8 @@ class GymWrapper(object):
 
   @property
   def reward_range(self):
-    if self._reward_range is None:
-      if hasattr(self, '_task') and hasattr(self._task, '_reward_range'):
-        self._reward_range = (-self._task._reward_range, 0)
-      else:
-        self._reward_range = gym_env.reward_range  # (-float('inf'), float('inf'))
-    return self._reward_range
+    # in general, self._task doesn't specify the limits of rewards
+    return gym_default_env.reward_range  # (-float('inf'), float('inf'))
 
   def _process_obs(self, obs):
     """Convert and processes observations."""

--- a/spriteworld/tasks.py
+++ b/spriteworld/tasks.py
@@ -212,7 +212,7 @@ class Clustering(AbstractTask):
     # Ignore objects unassigned to any cluster
     positions = positions[cluster_assignments >= 0]
     cluster_assignments = cluster_assignments[cluster_assignments >= 0]
-    return 1. / metrics.davies_bouldin_score(positions, cluster_assignments)
+    return 1. / np.maximum(0.01, metrics.davies_bouldin_score(positions, cluster_assignments))
 
   def reward(self, sprites):
     """Calculate reward from sprites.


### PR DESCRIPTION
Hello, a quick fix that gives GymWrapper a `reward_range` property, as required for subsequent Gym-type wrappers (see <https://github.com/openai/gym/blob/f2c9793eb762c26bb0b5524f5f69cdd536688f2e/gym/core.py#L212>)